### PR TITLE
Use kstreams in Subscriber

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,8 +5,7 @@
             :url "https://opensource.org/licenses/MIT"}
   :dependencies [[org.clojure/clojure "1.10.0"]
                  [com.stuartsierra/component "0.4.0"]
-                 [fundingcircle/jackdaw "0.6.4"]
-                 ;; FIXME: remove the following after jackdaw 0.6.5 released
+                 [fundingcircle/jackdaw "0.6.6"]
                  [org.apache.kafka/kafka-streams-test-utils "2.2.0"]
                  [cheshire "5.8.0"]]
   :scm {:url "git@github.com:rentpath/rp-jackdaw-clj.git"}

--- a/src/rp/jackdaw/subscriber.clj
+++ b/src/rp/jackdaw/subscriber.clj
@@ -10,10 +10,9 @@
 (defn topology-builder-fn
   [{:keys [topic-configs topic-kws callback-fn] :as component}]
   (fn [builder]
-    (doseq [topic-kw topic-kws]
-      (-> builder
-          (streams/kstream (get topic-configs topic-kw))
-          (streams/for-each! (fn [[k v]] (callback-fn {:component component :k k :v v})))))
+    (-> builder
+        (streams/kstreams (vals (select-keys topic-configs topic-kws)))
+        (streams/for-each! (fn [[k v]] (callback-fn {:component component :k k :v v}))))
     builder))
 
 (defn map->Subscriber


### PR DESCRIPTION
Now that the jackdaw release has my fix for kstreams, we can use that
instead of the hacky doseq workaround.