### PR TITLE
Permit lazyseqs

### DIFF
--- a/src/rp/jackdaw/serdes/homogeneous_edn.clj
+++ b/src/rp/jackdaw/serdes/homogeneous_edn.clj
@@ -124,6 +124,7 @@
 
 (s/def ::array (s/or :vector vector?
                      :list list?
+                     :seq seq?
                      :set ::set))
 
 (s/def ::map (s/and map?


### PR DESCRIPTION
[Card](https://rentpath.atlassian.net/browse/SRV-1117)

Because the kstream output may include lazy seqs, we need to allow for
these to be interpreted as arrays when passed to the serializer.