### PR TITLE
Ensure space preceding set literal

### DIFF
--- a/src/rp/jackdaw/serdes/homogeneous_edn.clj
+++ b/src/rp/jackdaw/serdes/homogeneous_edn.clj
@@ -36,17 +36,17 @@
           (.softspace))))))
 
 (defn- seq-printer
-  [open-str close-str]
+  [open-str close-str & [soft-space?]]
   (reify Printer$Fn
     (eval [this s writer]
       (.append
         (reduce (fn [^Printer writer v]
                   (.printValue writer v))
-                (.append writer open-str)
+                (.append (if soft-space? (.softspace writer) writer) open-str)
                 s)
         close-str))))
 
-(def set-printer (seq-printer "#{" "}"))
+(def set-printer (seq-printer "#{" "}" true))
 (def vec-printer (seq-printer "[" "]"))
 (def list-printer (seq-printer "(" ")"))
 

--- a/test/rp/jackdaw/serdes/homogeneous_edn_test.clj
+++ b/test/rp/jackdaw/serdes/homogeneous_edn_test.clj
@@ -153,4 +153,4 @@
                             :map    {"a" 1 "b" 2}
                             :struct {:a 1 :b 2}}
                            {:compact? true})
-           "{:int 1 :str\"hat\":kw :imakeyword :vec[1 2 3]:set#{1 3 2}:map{\"a\"1\"b\"2}:struct{:a 1 :b 2}}"))))
+           "{:int 1 :str\"hat\":kw :imakeyword :vec[1 2 3]:set #{1 3 2}:map{\"a\"1\"b\"2}:struct{:a 1 :b 2}}"))))


### PR DESCRIPTION
[Card](https://rentpath.atlassian.net/browse/SRV-1117)

Because the Clojure EDN reader interprets the hash mark in a string
such as the following: `{:somekey#{1 2 3}}` as being a part of the
preceding symbol (i.e. `:somekey#`), rather than an indicator that the
following data structure is a set (and not a map), it then tries to read
the subsequent structure as a map and fails (as it has an odd number of
values). This ensures that in the compact EDN format every set will be
serialized with a preceding space if one is not already enforced
otherwise.