### PR TITLE
Adding schema retrieval from schema registry to topic registry

### DIFF
--- a/src/rp/jackdaw/topic_registry.clj
+++ b/src/rp/jackdaw/topic_registry.clj
@@ -1,6 +1,7 @@
 (ns rp.jackdaw.topic-registry
   (:require [com.stuartsierra.component :as component]
-            [rp.jackdaw.resolver :as resolver]))
+            [rp.jackdaw.resolver :as resolver]
+            [rp.jackdaw.schema :as schema]))
 
 ;; `topic-metadata` is a map of "unresolved" topic metadata.
 (defrecord BaseTopicRegistry [topic-metadata serde-resolver-fn]
@@ -12,6 +13,24 @@
   (stop [this]
     this))
 
+(defn resolve-schema
+  [{:keys [schema-name schema-version]} schema-registry-url]
+  (schema/fetch-schema schema-registry-url schema-name schema-version))
+
+
+(defn resolve-schemata
+  [topic-metadata schema-registry-url]
+  (into {}
+        (map (fn [topic-kw {:keys [topic-name key-serde value-serde] :as topic-config}]
+               (let [{key-serde-keyword :serde-keyword} key-serde
+                     {value-serde-keyword :serde-keyword} value-serde]
+                 [topic-kw (-> topic-config
+                               (= key-serde-keyword :jackdaw.serdes.avro.confluent/serde)
+                               (assoc-in [:key-serde :schema] (resolve-schema key-serde schema-registry-url))
+                               (= value-serde-keyword :jackdaw.serdes.avro.confluent/serde)
+                               (assoc-in [:key-serde :schema] (resolve-schema value-serde schema-registry-url)))])))
+        topic-metadata))
+
 ;;
 ;; Note that `type-registry` may be `nil` or left unspecified.
 ;; In such a case jackdaw's default type registry will be used.
@@ -19,7 +38,7 @@
 
 (defn map->TopicRegistry
   [{:keys [topic-metadata schema-registry-url type-registry]}]
-  (map->BaseTopicRegistry {:topic-metadata topic-metadata
+  (map->BaseTopicRegistry {:topic-metadata    (resolve-schemata topic-metadata schema-registry-url)
                            :serde-resolver-fn (resolver/serde-resolver schema-registry-url type-registry)}))
 
 (defn map->MockTopicRegistry

--- a/src/rp/jackdaw/topic_registry.clj
+++ b/src/rp/jackdaw/topic_registry.clj
@@ -21,13 +21,15 @@
 (defn resolve-schemata
   [topic-metadata schema-registry-url]
   (into {}
-        (map (fn [topic-kw {:keys [topic-name key-serde value-serde] :as topic-config}]
+        (map (fn [topic-kw {:keys [key-serde value-serde] :as topic-config}]
                (let [{key-serde-keyword :serde-keyword} key-serde
                      {value-serde-keyword :serde-keyword} value-serde]
                  [topic-kw (-> topic-config
-                               (= key-serde-keyword :jackdaw.serdes.avro.confluent/serde)
+                               (and (= key-serde-keyword :jackdaw.serdes.avro.confluent/serde)
+                                    (not (contains? key-serde :schema)))
                                (assoc-in [:key-serde :schema] (resolve-schema key-serde schema-registry-url))
-                               (= value-serde-keyword :jackdaw.serdes.avro.confluent/serde)
+                               (and (= value-serde-keyword :jackdaw.serdes.avro.confluent/serde)
+                                    (not (contains? key-serde :schema)))
                                (assoc-in [:key-serde :schema] (resolve-schema value-serde schema-registry-url)))])))
         topic-metadata))
 


### PR DESCRIPTION
Presently, in order to even supply a topic registry driven by the Avro schema registry, we have to manually resolve the schema themselves prior to population. This adds a vector of auto-resolving the schema for confluent serdes.