### PR TITLE
Change to rentpath jackdaw branch

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,16 +5,8 @@
             :url "https://opensource.org/licenses/MIT"}
   :dependencies [[org.clojure/clojure "1.10.0"]
                  [com.stuartsierra/component "0.4.0"]
-                 [fundingcircle/jackdaw "0.7.4"
-                  :exclusions [org.apache.kafka/kafka-clients
-                               org.apache.kafka/kafka-streams
-                               io.confluent/kafka-avro-serializer
-                               io.confluent/kafka-schema-registry-client]]
-                 [org.apache.kafka/kafka-clients "2.5.0"]
-                 [org.apache.kafka/kafka-streams "2.5.0"]
+                 [com.rentpath/jackdaw "0.8.0"]
                  [org.apache.kafka/kafka-streams-test-utils "2.5.0"]
-                 [io.confluent/kafka-schema-registry-client "5.5.0"]
-                 [io.confluent/kafka-avro-serializer "5.5.0"]
                  [cheshire "5.8.0"]
                  [us.bpsm/edn-java "0.6.0"]
                  [com.fasterxml.jackson.core/jackson-core "2.11.0"]]


### PR DESCRIPTION
This updates the dependency to the rentpath branch of Jackdaw, which has recently been updated to Kafka/Confluent version 2.5.0/5.5.0 to take advantage of new rebalancing features in this later version.