### PR TITLE
Add a kafka streams processor implementation that allows the user to implement their own Processor IFace

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.rentpath/rp-jackdaw-clj "0.3.1-SNAPSHOT"
+(defproject com.rentpath/rp-jackdaw-clj "0.3.2-SNAPSHOT"
   :description "Clojure Kafka components using Jackdaw"
   :url "https://gitthub.com/rentpath/rp-jackdaw-clj"
   :license {:name "MIT"


### PR DESCRIPTION
[Card](https://rentpath.atlassian.net/browse/SRV-2322)

This PR extends the FundingCircle CljKStream type to implement an interface called IKStreamProcessor that allows the user to implement their own Processor interface in the style of the Transformer. Jackdaw's process! fn implements their version of the Processor interface and simply only applies a passed in xform to the stream. We need to add a scheduled call in our Processor init method to act as an elastic-search batch timeout.